### PR TITLE
update failing unit test in blank templates

### DIFF
--- a/blank-typescript/CHANGELOG.md
+++ b/blank-typescript/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+-   Update blank template unit test ([#49](https://github.com/brightlayer-ui/react-cli-templates/issues/49)).
 -   Updated material-ui version to v5.
 
 ## v1.1.2 (December 8, 2021)

--- a/blank-typescript/template/src/App.test.tsx
+++ b/blank-typescript/template/src/App.test.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme, StyledEngineProvider } from '@mui/material/styles';
+import * as BLUIThemes from '@brightlayer-ui/react-themes';
 import { App } from './App';
 
-test('renders lwelcome text', () => {
-    render(<App />);
+test('renders welcome text', () => {
+    render(
+        <StyledEngineProvider injectFirst>
+            <ThemeProvider theme={createTheme(BLUIThemes.blue)}>
+                    <App />
+            </ThemeProvider>
+        </StyledEngineProvider>
+    );
     const bluiText = screen.getByText(/Welcome to Brightlayer/i);
     expect(bluiText).toBeInTheDocument();
 });

--- a/blank/CHANGELOG.md
+++ b/blank/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+-   Update blank template unit test ([#49](https://github.com/brightlayer-ui/react-cli-templates/issues/49)).
 -   Updated material-ui version to v5.
 
 ## v1.1.2 (December 8, 2021)

--- a/blank/template/src/App.test.jsx
+++ b/blank/template/src/App.test.jsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme, StyledEngineProvider } from '@mui/material/styles';
+import * as BLUIThemes from '@brightlayer-ui/react-themes';
 import { App } from './App';
 
 test('renders welcome text', () => {
-    render(<App />);
+    render(
+        <StyledEngineProvider injectFirst>
+            <ThemeProvider theme={createTheme(BLUIThemes.blue)}>
+                    <App />
+            </ThemeProvider>
+        </StyledEngineProvider>
+    );
     const bluiText = screen.getByText(/Welcome to Brightlayer/i);
     expect(bluiText).toBeInTheDocument();
 });


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
[#49 ](https://github.com/brightlayer-ui/react-cli-templates/issues/49) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- update blank unit test to use StyledEngineProvider
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- 
npx -p @ brightlayer-ui /cli blui new react --template file:/Users/xxxx/pxblue/react-cli-templates/authentication-typescript