### PR TITLE
Remove @mui/styles from templates

### DIFF
--- a/authentication-typescript/CHANGELOG.md
+++ b/authentication-typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.2.0 (December 15, 2022)
+
+### Changed
+
+-   Updated dependencies.
+-   Removed dependency on @mui/styles ([#71](https://github.com/brightlayer-ui/react-workflows/issues/71)).
+
 ## v2.1.0 (June 27, 2022)
 
 ### Changed

--- a/authentication-typescript/package.json
+++ b/authentication-typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/cra-template-authentication-typescript",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "keywords": [
         "react",
         "create-react-app",

--- a/authentication-typescript/template.json
+++ b/authentication-typescript/template.json
@@ -1,16 +1,15 @@
 {
     "package": {
         "dependencies": {
-            "@mui/material": "^5.5.0",
-            "@mui/icons-material": "^5.5.0",
-            "@mui/styles": "^5.5.0",
+            "@mui/material": "^5.10.15",
+            "@mui/icons-material": "^5.10.15",
             "@emotion/css": "^11.9.0",
             "@emotion/react": "^11.8.2",
             "@emotion/styled": "^11.8.1",
-            "@brightlayer-ui/react-auth-workflow": "^3.1.0",
-            "@brightlayer-ui/react-themes": "^7.0.0",
-            "@brightlayer-ui/react-components": "^6.1.0",
-            "@brightlayer-ui/icons-mui": "^3.0.0",
+            "@brightlayer-ui/react-auth-workflow": "^3.1.1",
+            "@brightlayer-ui/react-themes": "^7.1.0",
+            "@brightlayer-ui/react-components": "^6.1.2",
+            "@brightlayer-ui/icons-mui": "^3.3.0",
             "react-app-polyfill": "latest",
             "date-fns": "latest",
             "i18next": "^21.0.0",

--- a/blank-typescript/CHANGELOG.md
+++ b/blank-typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.2.0 (December 15, 2022)
+
+### Changed
+
+-   Updated dependencies.
+-   Removed dependency on @mui/styles ([#71](https://github.com/brightlayer-ui/react-workflows/issues/71)).
+
 ## v2.1.0 (June 27, 2022)
 
 ### Changed

--- a/blank-typescript/package.json
+++ b/blank-typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/cra-template-blank-typescript",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "keywords": [
         "react",
         "create-react-app",

--- a/blank-typescript/template.json
+++ b/blank-typescript/template.json
@@ -1,15 +1,14 @@
 {
     "package": {
         "dependencies": {
-            "@mui/material": "^5.5.0",
-            "@mui/icons-material": "^5.5.0",
-            "@mui/styles": "^5.5.0",
+            "@mui/material": "^5.10.15",
+            "@mui/icons-material": "^5.10.15",
             "@emotion/css": "^11.9.0",
             "@emotion/react": "^11.8.2",
             "@emotion/styled": "^11.8.1",
-            "@brightlayer-ui/react-themes": "^7.0.0",
-            "@brightlayer-ui/react-components": "^6.1.0",
-            "@brightlayer-ui/icons-mui": "^3.0.0",
+            "@brightlayer-ui/react-themes": "^7.1.0",
+            "@brightlayer-ui/react-components": "^6.1.2",
+            "@brightlayer-ui/icons-mui": "^3.3.0",
             "@brightlayer-ui/colors": "^3.0.1",
             "react-app-polyfill": "latest",
             "web-vitals": "2.1.4"

--- a/routing-typescript/CHANGELOG.md
+++ b/routing-typescript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.2.0 (December 15, 2022)
+
+### Changed
+
+-   Updated dependencies.
+-   Removed dependency on @mui/styles ([#71](https://github.com/brightlayer-ui/react-workflows/issues/71)).
+
 ## v2.1.0 (June 27, 2022)
 
 ### Changed

--- a/routing-typescript/package.json
+++ b/routing-typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/cra-template-routing-typescript",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "keywords": [
         "react",
         "create-react-app",

--- a/routing-typescript/template.json
+++ b/routing-typescript/template.json
@@ -1,15 +1,14 @@
 {
     "package": {
         "dependencies": {
-            "@mui/material": "^5.5.0",
-            "@mui/icons-material": "^5.5.0",
-            "@mui/styles": "^5.5.0",
+            "@mui/material": "^5.10.15",
+            "@mui/icons-material": "^5.10.15",
             "@emotion/css": "^11.9.0",
             "@emotion/react": "^11.8.2",
             "@emotion/styled": "^11.8.1",
-            "@brightlayer-ui/react-themes": "^7.0.0",
-            "@brightlayer-ui/react-components": "^6.1.0",
-            "@brightlayer-ui/icons-mui": "^3.0.0",
+            "@brightlayer-ui/react-themes": "^7.1.0",
+            "@brightlayer-ui/react-components": "^6.1.2",
+            "@brightlayer-ui/icons-mui": "^3.3.0",
             "@brightlayer-ui/colors": "^3.0.1",
             "react-app-polyfill": "latest",
             "react-router": "^6.3.0",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes BLUI-3662 #71.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove @mui/styles from templates
- Use latest BLUI dependencies

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- The js templates will be deprecated soon so the typescript templates are the only ones that need to be tested here.
- clone this repo and checkout the `feature/3662/remove-mui-styles-dependency` branch
- Test templates by generating new projects via the cli
- `npx -p @brightlayer-ui/cli blui new --template=file:<path-to-template>`
- Here's an example of what this command looks like for generating a new authentication template for me locally: `npx -p @brightlayer-ui/cli blui new --template=file:/Users/e#######/Dev/react-cli-templates/authentication-typescript`
- be sure to test all 3 templates (blank-typescript, routing-typescript, authentication-typescript)
